### PR TITLE
fix a parse error when stdout is not a json string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ module.exports = async (url, flags, opts) => {
   const { stdout } = await execa(YOUTUBE_DL_PATH, args(url, flags), opts)
   try {
     return JSON.parse(stdout)
-  } catch(e) {
+  } catch (e) {
     return stdout
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ module.exports = async (url, flags, opts) => {
   try {
     return JSON.parse(stdout)
   } catch(e) {
-    return std
+    return stdout
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,11 @@ const args = (url, flags = {}) => [].concat(url, dargs(flags)).filter(Boolean)
 
 module.exports = async (url, flags, opts) => {
   const { stdout } = await execa(YOUTUBE_DL_PATH, args(url, flags), opts)
-  return JSON.parse(stdout)
+  try {
+    return JSON.parse(stdout)
+  } catch(e) {
+    return std
+  }
 }
 
 module.exports.args = args


### PR DESCRIPTION
When I using the code below to get available formats
```javascript
const youtubedl = require('youtube-dl-exec')

youtubedl('https://example.com', {
  listFormats: true,
  noWarnings: true,
  noCallHome: true,
  noCheckCertificate: true,
  referer: 'https://example.com'
})
  .then(output => console.log(output))
```
I got an error :
```
SyntaxError: Unexpected token y in JSON at position 1
    at JSON.parse (<anonymous>)
    at module.exports (xxxxxx/node_modules/youtube-dl-exec/src/index.js:13:15)
```
seems like youtube-dl's stdout may not always be a json string