### PR TITLE
fix: single-character-flags with values are now supported

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ const execa = require('execa')
 
 const { YOUTUBE_DL_PATH } = require('./constants')
 
-const args = (url, flags = {}) => [].concat(url, dargs(flags)).filter(Boolean)
+const args = (url, flags = {}) =>
+  [].concat(url, dargs(flags, { useEquals: false })).filter(Boolean)
 
 const isJSON = str => str.startsWith('{')
 

--- a/test/args.js
+++ b/test/args.js
@@ -23,8 +23,11 @@ test('parse arguments into flags', async t => {
     '--no-check-certificate',
     '--prefer-free-formats',
     '--youtube-skip-dash-manifest',
-    '--referer=https://example.com',
-    '--car-dir=/tmp',
-    '--user-agent=googlebot'
+    '--referer',
+    'https://example.com',
+    '--car-dir',
+    '/tmp',
+    '--user-agent',
+    'googlebot'
   ])
 })


### PR DESCRIPTION
Youtube-dl does not support `-foo=bar` styled single-character-flags.

This commit disables such styling completely, by using spaces instead of `=`