### PR TITLE
Exported type YtResponse

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -32,7 +32,7 @@ declare module 'youtube-dl-exec' {
         id: string,
     }
 
-    type YtResponse = {
+    export type YtResponse = {
         id: string,
         title: string,
         formats: YtFormat[],


### PR DESCRIPTION
Marked type `YtResponse` with `export` to be used as a variable type.