### PR TITLE
Fix Typo in Readme: dump-json->dump-single-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ youtubedl('https://example.com', {
 It's equivalent to:
 
 ```bash
-$ youtube-dl https://example.com --dump-json --no-warnings --no-call-home --no-check-certificate --prefer-free-formats --youtube-skip-dash-manifest --referer=https://example.com
+$ youtube-dl https://example.com --dump-single-json --no-warnings --no-call-home --no-check-certificate --prefer-free-formats --youtube-skip-dash-manifest --referer=https://example.com
 ```
 
 ## API


### PR DESCRIPTION
`dumpSingleJson` is equivalent to `--dump-single-json` instead of `--dump-json`

related: https://github.com/microlinkhq/youtube-dl-exec/issues/15