### PR TITLE
feat: read npm_config environment variables

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -8,18 +8,20 @@ const PLATFORM_UNIX = 'unix'
 
 const YOUTUBE_DL_HOST =
   process.env.YOUTUBE_DL_HOST ||
+  process.env.npm_config_YOUTUBE_DL_HOST ||
   'https://api.github.com/repos/ytdl-org/youtube-dl/releases?per_page=1'
 
 const YOUTUBE_DL_DIR =
-  process.env.YOUTUBE_DL_DIR || path.join(__dirname, '..', 'bin')
+  process.env.YOUTUBE_DL_DIR || process.env.npm_config_YOUTUBE_DL_DIR || path.join(__dirname, '..', 'bin')
 
 const YOUTUBE_DL_PLATFORM =
-  process.env.YOUTUBE_DL_PLATFORM || isUnix(process.platform)
+  process.env.YOUTUBE_DL_PLATFORM || process.env.npm_config_YOUTUBE_DL_PLATFORM || isUnix(process.platform)
     ? PLATFORM_UNIX
     : PLATFORM_WIN
 
 const YOUTUBE_DL_FILENAME =
   process.env.YOUTUBE_DL_FILENAME ||
+  process.env.npm_config_YOUTUBE_DL_FILENAME ||
   `youtube-dl${YOUTUBE_DL_PLATFORM === PLATFORM_WIN ? '.exe' : ''}`
 
 const YOUTUBE_DL_PATH = path.join(YOUTUBE_DL_DIR, YOUTUBE_DL_FILENAME)


### PR DESCRIPTION
I want to use the `.npmrc` file to set `YOUTUBE_DL_HOST` and `YOUTUBE_DL_FILENAME`, these config can be accessed from `process.env.npm_config_<env>` for example: `process.env.npm_config_YOUTUBE_DL_FILENAME`.