### PR TITLE
Fix(windows): npm run check

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "src"
   ],
   "scripts": {
-    "check": "bin-version-check python '>=2'",
+    "check": "bin-version-check python \">=2\"",
     "clean": "rm -rf node_modules",
     "contributors": "(git-authors-cli && finepack && git add package.json && git commit -m 'build: contributors' --no-verify) || true",
     "coverage": "nyc report --reporter=text-lcov | coveralls",


### PR DESCRIPTION
### Error log
```
> youtube-dl-exec@1.2.11 check
> bin-version-check python '>=2'

Error: Invalid version range
```

### Fix
This PR fix above mentioned issue, which cause error while installation.