### PR TITLE
fix: npm_config environment variables on npm v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ setTimeout(subprocess.cancel, 30000)
 
 The environment variables are taken into account when you perform a `npm install` in a project that contains `youtube-dl-exec` dependency.
 
+These environment variables can also be set through "npm config", for example `npm install --YOUTUBE_DL_HOST="Some URL"`, or store it in `.npmrc` file.
+
 They setup the download configuration for getting the `youtube-dl` binary file.
 
 These variables can be

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,23 +6,20 @@ const path = require('path')
 const PLATFORM_WIN = 'win32'
 const PLATFORM_UNIX = 'unix'
 
-const YOUTUBE_DL_HOST =
-  process.env.YOUTUBE_DL_HOST ||
-  process.env.npm_config_YOUTUBE_DL_HOST ||
-  'https://api.github.com/repos/ytdl-org/youtube-dl/releases?per_page=1'
+function get (key) {
+  if (!key) return undefined
+  return process.env[key] || process.env[`npm_config_${key.toLowerCase()}`]
+}
 
-const YOUTUBE_DL_DIR =
-  process.env.YOUTUBE_DL_DIR || process.env.npm_config_YOUTUBE_DL_DIR || path.join(__dirname, '..', 'bin')
+const YOUTUBE_DL_HOST = get('YOUTUBE_DL_HOST') || 'https://api.github.com/repos/ytdl-org/youtube-dl/releases?per_page=1'
 
-const YOUTUBE_DL_PLATFORM =
-  process.env.YOUTUBE_DL_PLATFORM || process.env.npm_config_YOUTUBE_DL_PLATFORM || isUnix(process.platform)
-    ? PLATFORM_UNIX
-    : PLATFORM_WIN
+const YOUTUBE_DL_DIR = get('YOUTUBE_DL_DIR') || path.join(__dirname, '..', 'bin')
 
-const YOUTUBE_DL_FILENAME =
-  process.env.YOUTUBE_DL_FILENAME ||
-  process.env.npm_config_YOUTUBE_DL_FILENAME ||
-  'youtube-dl'
+const YOUTUBE_DL_PLATFORM = get('YOUTUBE_DL_PLATFORM') || isUnix(process.platform)
+  ? PLATFORM_UNIX
+  : PLATFORM_WIN
+
+const YOUTUBE_DL_FILENAME = get('YOUTUBE_DL_FILENAME') || 'youtube-dl'
 
 const YOUTUBE_DL_FILE = !YOUTUBE_DL_FILENAME.endsWith('.exe') && YOUTUBE_DL_PLATFORM === 'win32' ? `${YOUTUBE_DL_FILENAME}.exe` : YOUTUBE_DL_FILENAME
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,7 +8,7 @@ const PLATFORM_UNIX = 'unix'
 
 function get (key) {
   if (!key) return undefined
-  return process.env[key] || process.env[`npm_config_${key.toLowerCase()}`]
+  return process.env[key] || process.env[`npm_config_${key.toLowerCase()}`] || process.env[`npm_config_${key.toUpperCase()}`]
 }
 
 const YOUTUBE_DL_HOST = get('YOUTUBE_DL_HOST') || 'https://api.github.com/repos/ytdl-org/youtube-dl/releases?per_page=1'


### PR DESCRIPTION
Starting with npm v7 `npm_config` environment variables from `.npmrc` or `npm config set <key> <value>` will always be lowercase in `process.env`