### PR TITLE
fix: never treat a url as an arg

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ const execa = require('execa')
 const { YOUTUBE_DL_PATH } = require('./constants')
 
 const args = (url, flags = {}) =>
-  [].concat(url, dargs(flags, { useEquals: false })).filter(Boolean)
+  dargs({ ...flags, '--': [url] }, { useEquals: false }).filter(Boolean)
 
 const isJSON = (str = '') => str.startsWith('{')
 

--- a/test/args.js
+++ b/test/args.js
@@ -17,7 +17,6 @@ test('parse arguments into flags', async t => {
   })
 
   t.deepEqual(flags, [
-    'https://example',
     '--no-warnings',
     '--no-call-home',
     '--no-check-certificate',
@@ -28,6 +27,8 @@ test('parse arguments into flags', async t => {
     '--car-dir',
     '/tmp',
     '--user-agent',
-    'googlebot'
+    'googlebot',
+    '--',
+    'https://example'
   ])
 })


### PR DESCRIPTION
Case Study: https://www.youtube.com/watch?v=-QuVe-hjMs0

| expectation | reality |
| ----------- | ------- |
| `youtube-dl -- -QuVe-hjMs0` | `youtube-dl -QuVe-hjMs0` |

This makes youtube-dl incorrectly attempt to parse the query as arguments.
This fix ensures this never happens.