### PR TITLE
fix: typescript typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -92,4 +92,8 @@ declare module 'youtube-dl-exec' {
 
     export default function(url: string, flags?: unknown, options?: Options<string>): Promise<YtResponse>;
     export function raw(url: string, flags?: unknown, options?: Options<string>): ExecaChildProcess;
+    export function create(binaryPath?: string): {
+        (url: string, flags?: unknown, options?: Options<string>): Promise<YtResponse>;
+        raw(url: string, flags?: unknown, options?: Options<string>): ExecaChildProcess;
+    }
 }


### PR DESCRIPTION
You forgot to update the typings in d4f06a9967c4f654dc532105b74a5669f689bc39.

Also, I saw two more functions that isn't available in `index.d.ts`
```js
module.exports.args = args
module.exports.isJSON = isJSON
```
Should I add those too to the typings? I feel that those two are internal functions in `youtube-dl-exec`.