### PR TITLE
Functions for running youtube-dl by passing a YtResponse

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -248,5 +248,7 @@ declare module 'youtube-dl-exec' {
     export function create(binaryPath?: string): {
         (url: string, flags?: YtFlags, options?: Options<string>): Promise<YtResponse>;
         raw(url: string, flags?: YtFlags, options?: Options<string>): ExecaChildProcess;
+        getDownloadInfo(url: string, flags?: YtFlags, options?: Options<string>) : Promise<YtResponse>;
+        fromDownloadInfo(info: YtResponse, flags?: YtFlags, options?: Options<string>) : Promise<YtResponse>;
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,19 @@ const parse = ({ stdout }) => (isJSON(stdout) ? JSON.parse(stdout) : stdout)
 const create = binaryPath => {
   const fn = (url, flags, opts) => fn.raw(url, flags, opts).then(parse)
   fn.raw = (url, flags, opts) => execa(binaryPath, args(url, flags), opts)
+  fn.getDownloadInfo = (url, flags, opts) => {
+    flags ||= {}
+    flags.dumpSingleJson = true
+    return fn.raw(url, flags, opts).then(parse)
+  }
+  fn.fromDownloadInfo = (info, flags, opts) => {
+    flags ||= {}
+    flags.loadInfoJson = '-'
+    const process = execa(binaryPath, dargs(flags, { useEquals: false }), opts)
+    process.stdin.write(JSON.stringify(info))
+    process.stdin.end()
+    return process.then(parse)
+  }
   return fn
 }
 


### PR DESCRIPTION
While making the previous pull request I noticed the flags `--dump-single-json` and `--load-info-json`, these flags allow you to get the info that youtube-dl extracts and then loading it back in, so that it hasn't to extract the contents of the page again.
This, I think, is a pretty unknown feature of youtube-dl, so if this feature dosen't get pulled I undestand, but it allows some cool usages:
```js
const ytdlRaw = require('youtube-dl-exec')
const ytdl = ytdlRaw.create('/usr/bin/youtube-dl')

async function main() {
    const rick = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'

    // with this function we get a YtResponse with all the info about the video
    // this info can be read and used and then passed again to youtube-dl, without having to querying it again
    let info = await ytdl.getDownloadInfo(rick)
    
    // the info the we retrive can be read directly or passed to youtube-dl
    console.log(info.description)
    console.log(await ytdl.fromDownloadInfo(info, { listThumbnails: true }))
     
    // the code below would have the same output as the code above,
    // but it has to download the youtube page again
    //console.log(await ytdl(rick, { listThumbnails: true }))
    
    // and finally is possible to download the video
    await ytdl.fromDownloadInfo(info, { output: `downloads/${info.title}`})
    
    process.exit()
}

main()
```

sorry for the closed pulled request I used the wrong indentation.
If this gets merged I can document these functions in the readme.
Well hope this was usefull, have a good day.
