### PR TITLE
fix: typo error

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -132,7 +132,7 @@ declare module 'youtube-dl-exec' {
         noPlaylist?: boolean,
         yesPlaylist?: boolean,
         ageLimit?: number,
-        dowloadArchive?: string,
+        downloadArchive?: string,
         includeAds?: boolean,
         limitRate?: string,
         retries?: number | 'infinite',


### PR DESCRIPTION
download archive command was not working because of a typo. It was 'dowloadArchive' missing an 'n'.