### PR TITLE
fix: blacklist undocumented "--no-" args

### DIFF
--- a/src/args.js
+++ b/src/args.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const dargs = require('dargs')
+
+const ignoreFalseFor = ['ignoreErrors']
+
+const filterByKeys = (o, toExclude) =>
+  Object.fromEntries(Object.entries(o).filter(([k]) => !toExclude.includes(k)))
+
+const filterFlags = (flags) => filterByKeys(flags, ignoreFalseFor)
+
+const args = (url, flags = {}) =>
+  [].concat(url, dargs(filterFlags(flags), { useEquals: false })).filter(Boolean)
+
+module.exports = args

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,9 @@
 'use strict'
 
-const dargs = require('dargs')
 const execa = require('execa')
 
 const constants = require('./constants')
-
-const args = (url, flags = {}) =>
-  [].concat(url, dargs(flags, { useEquals: false })).filter(Boolean)
+const args = require('./args')
 
 const isJSON = (str = '') => str.startsWith('{')
 

--- a/test/args.js
+++ b/test/args.js
@@ -31,3 +31,13 @@ test('parse arguments into flags', async t => {
     'googlebot'
   ])
 })
+
+test('undocumented "--no-" args are ignored', async t => {
+  const flags = args('https://example', {
+    ignoreErrors: false
+  })
+
+  t.deepEqual(flags, [
+    'https://example'
+  ])
+})


### PR DESCRIPTION
**Rationale:**

When `ignoreErrors: false,` is used in YtFlags, although being a valid option,  the program would fail with `youtube-dl: error: no such option: --no-ignore-errors` error.

Indeed, `dargs` without `ignoreFalse: true` would yield an invalid `--no-ignore-errors` argument for yourtube-dl script (the latest version `2021.12.17` at the moment).

**Solution**

Although at least two types of solutions could be implemented, namely whitelist and blacklist, this PR goes the "blacklist" way. The reason being any potential `--no-...` arguments possibly being added in the new youtube-dl versions won't be blocked by youtube-dl-exec code.

The whitelist solution would be more strict and less "update-prone". Please let me know if you'd like the "whitelist" solution better, I'll change the PR accordingly. 

The third way to fix this could be using `ignoreFalse: true` for dargs and adding `no`-prefixed options in the code. It would be a nice modification to the "whitelist" solution.

**Further progress**

More arguments that don't support `--no-` could be easily added to `ignoreFalseFor` which I'll do when the solution used for this issue is agreed upon.
