### PR TITLE
Updated wrong type for type addHeader.

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -199,7 +199,7 @@ declare module 'youtube-dl-exec' {
         preferInsecure?: boolean,
         userAgent?: string,
         referer?: string,
-        addHeader?: string,
+        addHeader?: string[],
         bidiWorkaround?: boolean,
         sleepInterval?: number,
         maxSleepInterval?: number,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -195,7 +195,7 @@ declare module 'youtube-dl-exec' {
         printTraffic?: boolean,
         callHome?: boolean,
         encoding?: string,
-        noCheckCertificate?: boolean,
+        noCheckCertificates?: boolean,
         preferInsecure?: boolean,
         userAgent?: string,
         referer?: string,


### PR DESCRIPTION
Type addHeader is taking string array(Referenced from readme.md). Declared as string.
for example: 
```
const youtubedl = require('youtube-dl-exec')

youtubedl('https://www.youtube.com/watch?v=6xKWiCMKKJg', {
  dumpSingleJson: true,
  noCheckCertificates: true,
  noWarnings: true,
  preferFreeFormats: true,
  addHeader: [
    'referer:youtube.com',
    'user-agent:googlebot'
  ]

}).then(output => console.log(output))
```