### PR TITLE
125 types for `exec` don't seem to be applied properly

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -244,10 +244,20 @@ declare module 'youtube-dl-exec' {
         convertSubs?: string
     }
 
-    export default function(url: string, flags?: YtFlags, options?: Options<string>): Promise<YtResponse>;
-    export function exec(url: string, flags?: YtFlags, options?: Options<string>): ExecaChildProcess;
-    export function create(binaryPath?: string): {
-        (url: string, flags?: YtFlags, options?: Options<string>): Promise<YtResponse>;
-        exec(url: string, flags?: YtFlags, options?: Options<string>): ExecaChildProcess;
+    type YtdlExecFunction = (url: string, flags?: YtFlags, options?: Options<string>) => ExecaChildProcess;
+    type YtdlCreateFuncion = (binaryPath: string) => {
+      (url: string, flags?: YtFlags, options?: Options<string>): Promise<YtResponse>,
+      exec: YtdlExecFunction,
     }
+
+    const youtubeDl: (
+      (url: string, flags?: YtFlags, options?: Options<string>) => Promise<YtResponse>
+    ) & {
+      exec: YtdlExecFunction,
+      create: YtdlCreateFuncion,
+    }
+
+    export default youtubeDl;
+    export function exec(...[url, flags, options]: Parameters<YtdlExecFunction>): ReturnType<YtdlExecFunction>;
+    export function create(...[binaryPath]: Parameters<YtdlCreateFuncion>): ReturnType<YtdlCreateFuncion>;
 }


### PR DESCRIPTION
The existing Typescript defs weren't recognized as properties of the default export, so attempting to use them in a Typescript project cause an error.
add types for exec and create functions

As far as I can tell this is the only way to export the exec and create functions both as function properties and individual exports.
