### PR TITLE
feat: preinstall check for python or python3 version >=3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lint": "standard-markdown README.md && standard",
     "postinstall": "node scripts/postinstall.js",
     "postrelease": "npm run release:tags && npm run release:github && (ci-publish || npm publish --access=public)",
-    "preinstall": "npx bin-version-check-cli python3 \"> =3.7\"",
+    "preinstall": "npx bin-version-check-cli python3 \"> =3.7\" || npx bin-version-check-cli python \"> =3.7\"",
     "prerelease": "npm run update:check && npm run contributors",
     "pretest": "npm run lint",
     "release": "standard-version -a",


### PR DESCRIPTION
## Implements
- preinstall now checks for either python3 or python version being >= to 3.7