### PR TITLE
Added missing response type manifest_url

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,6 +13,7 @@ declare module 'youtube-dl-exec' {
         tbr: number,
         vbr?: number,
         url: string,
+      	manifest_url: string,
         width: number,
         ext: string,
         vcodec: string,


### PR DESCRIPTION
manifest_url is exist in formats response but not exist in typescript types.