### PR TITLE
feat: normalize errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@
 
 ## Install
 
+> **Note**: It requires Python 3.7 or above available in your system as `python3`. Otherwise, the library will throw an error.
+
 ```bash
 $ npm install youtube-dl-exec --save
 ```
 
-Also, it requires Python 3.7 or above available in your system as `python3`. Otherwise, the library will throw an error.
+By default, the library will auto-install the latest `yt-dlp` available that will downloaded on [build](https://github.com/microlinkhq/youtube-dl-exec/blob/master/package.json#L70) time.
 
 ## Usage
+
+Any `yt-dlp` flags is supported:
 
 ```js
 const youtubedl = require('youtube-dl-exec')
@@ -55,17 +59,35 @@ $ ./bin/yt-dlp \
   'https://www.youtube.com/watch?v=6xKWiCMKKJg'
 ```
 
-The library will use the latest `yt-dlp` available that will downloaded on [build](https://github.com/microlinkhq/youtube-dl-exec/blob/master/package.json#L70) time.
+Type `yt-dlp --help` for seeing all of them.
 
-Alternatively, you can specify your own binary path using [`.create`]():
+## Custom binary
+
+In case you need, you can specify your own binary path using [`.create`]():
 
 ```js
 const { create: createYoutubeDl } = require('youtube-dl-exec')
-
 const youtubedl = createYoutubeDl('/my/binary/path')
 ```
 
-You can combine it with [YOUTUBE_DL_SKIP_DOWNLOAD](#youtube_dl_skip_download). See [environment variables](#environment-variables) to know more.
+## Progress bar
+
+Since the library is returning a promise, you can use any library that makes a progress estimation taking a promise as input:
+
+```js
+const logger = require('progress-estimator')()
+const youtubedl = require('youtube-dl-exec')
+
+const url = 'https://www.youtube.com/watch?v=6xKWiCMKKJg'
+const promise = youtubedl(url, { dumpSingleJson: true })
+const result = await logger(promise, `Obtaining ${url}`)
+
+console.log(result)
+```
+
+Alternatively, you can access to the subprocess to have more granular control. See [youtubedl.exec](https://github.com/microlinkhq/youtube-dl-exec#youtubedlexecurl-flags-options).
+
+Also, combine that with [YOUTUBE_DL_SKIP_DOWNLOAD](#youtube_dl_skip_download). See [environment variables](#environment-variables) to know more.
 
 ## API
 
@@ -92,7 +114,7 @@ Any option provided here will passed to [execa#options](https://github.com/sindr
 
 ### youtubedl.exec(url, [flags], [options])
 
-Similar to main method but instead of a parsed output, it will return the internal subprocess object
+Similar to main method but instead of a parsed output, it will return the internal subprocess object:
 
 ```js
 const youtubedl = require('youtube-dl-exec')

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "prettier-standard": "latest",
     "simple-git-hooks": "latest",
     "standard": "latest",
-    "standard-markdown": "latest",
     "standard-version": "latest"
   },
   "engines": {
@@ -63,7 +62,7 @@
     "clean": "rm -rf node_modules",
     "contributors": "(npx git-authors-cli && npx finepack && git add package.json && git commit -m 'build: contributors' --no-verify) || true",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "lint": "standard-markdown README.md && standard",
+    "lint": "standard",
     "postinstall": "node scripts/postinstall.js",
     "postrelease": "npm run release:tags && npm run release:github && (ci-publish || npm publish --access=public)",
     "preinstall": "npx bin-version-check-cli python3 \"> =3.7\" || npx bin-version-check-cli python \"> =3.7\"",
@@ -85,9 +84,6 @@
   "nano-staged": {
     "*.js,!*.min.js,": [
       "prettier-standard"
-    ],
-    "*.md": [
-      "standard-markdown"
     ],
     "package.json": [
       "finepack"

--- a/src/index.js
+++ b/src/index.js
@@ -10,10 +10,14 @@ const args = (url, flags = {}) =>
 
 const isJSON = (str = '') => str.startsWith('{')
 
-const parse = ({ stdout }) => (isJSON(stdout) ? JSON.parse(stdout) : stdout)
+const parse = ({ stdout, stderr, ...details }) => {
+  if (!stderr) return isJSON(stdout) ? JSON.parse(stdout) : stdout
+  throw Object.assign(new Error(stderr), details)
+}
 
 const create = binaryPath => {
-  const fn = (url, flags, opts) => fn.exec(url, flags, opts).then(parse)
+  const fn = (url, flags, opts) =>
+    fn.exec(url, flags, opts).then(parse).catch(parse)
   fn.exec = (url, flags, opts) => execa(binaryPath, args(url, flags), opts)
   return fn
 }

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const test = require('ava')
+
+const youtubedl = require('..')
+
+test('unsupported URLs', async t => {
+  t.plan(4)
+  const url = 'https://www.apple.com/homepod'
+  try {
+    await youtubedl(url, { dumpSingleJson: true, noWarnings: true })
+  } catch (error) {
+    t.is(
+      error.message,
+      'ERROR: Unsupported URL: https://www.apple.com/homepod/'
+    )
+    t.true(error instanceof Error)
+    t.truthy(error.command)
+    t.truthy(error.exitCode)
+  }
+})
+
+test('video unavailable', async t => {
+  t.plan(4)
+  const url = 'https://www.youtube.com/watch?v=x8erEF_1POY'
+  try {
+    await youtubedl(url, { dumpSingleJson: true })
+  } catch (error) {
+    t.is(
+      error.message,
+      'ERROR: [youtube] x8erEF_1POY: Video unavailable. The uploader has not made this video available in your country'
+    )
+    t.true(error instanceof Error)
+    t.truthy(error.command)
+    t.truthy(error.exitCode)
+  }
+})


### PR DESCRIPTION
Some `yt-dlp` errors were not being exposed because they were not being detected correctly.