### PR TITLE
feat: move preinstall command into a separate script

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "youtube-downloader"
   ],
   "dependencies": {
+    "bin-version-check": "~5.0.0",
     "dargs": "~7.0.0",
     "execa": "~5.1.0",
     "is-unix": "~2.0.1",
@@ -137,7 +138,7 @@
     "lint": "standard",
     "postinstall": "node scripts/postinstall.js",
     "postrelease": "npm run release:tags && npm run release:github && (ci-publish || npm publish --access=public)",
-    "preinstall": "[[ -n \"${YOUTUBE_DL_SKIP_PYTHON_CHECK}\" ]] || (npx bin-version-check-cli python3 \"> =3.7\" || npx bin-version-check-cli python \"> =3.7\")",
+    "preinstall": "node scripts/preinstall.mjs",
     "prerelease": "npm run update:check",
     "pretest": "npm run lint",
     "release": "standard-version -a",

--- a/scripts/preinstall.mjs
+++ b/scripts/preinstall.mjs
@@ -1,0 +1,20 @@
+import binaryVersionCheck from 'bin-version-check'
+
+const throwError = error => {
+  throw new Error(
+    `youtube-dl-exec needs Python. ${error.message}. You can skip this check passing \`YOUTUBE_DL_SKIP_PYTHON_CHECK=1\``
+  )
+}
+
+const pReflect = p =>
+  Promise.resolve(p)
+    .then(() => ({ isError: false }))
+    .catch(error => ({ isError: true, error }))
+
+if (process.env.YOUTUBE_DL_SKIP_PYTHON_CHECK !== undefined) process.exit(0)
+
+let result = await pReflect(binaryVersionCheck('python3', '>=3.7'))
+if (!result.isError) process.exit(0)
+
+result = await pReflect(binaryVersionCheck('python', '>=3.7'))
+if (result.isError) throwError(result.error)


### PR DESCRIPTION
It's more flexible and offer granular error handling than run a npx command wrapped by bash.

Closes https://github.com/microlinkhq/youtube-dl-exec/issues/142