### PR TITLE
fix: update bin-version-check to remove security warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "youtube-downloader"
   ],
   "dependencies": {
-    "bin-version-check": "~5.0.0",
+    "bin-version-check": "~5.1.0",
     "dargs": "~7.0.0",
     "execa": "~5.1.0",
     "is-unix": "~2.0.1",


### PR DESCRIPTION
The current version (2.3.1) gives security warnings in npm:

```shell
% npm audit --production
npm WARN config production Use `--omit=dev` instead.
# npm audit report

semver  <7.5.2
Severity: moderate
semver vulnerable to Regular Expression Denial of Service - https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
fix available via `npm audit fix --force`
Will install bin-version-check@5.1.0, which is outside the stated dependency range
node_modules/semver-truncate/node_modules/semver
  semver-truncate  <=2.0.0
  Depends on vulnerable versions of semver
  node_modules/semver-truncate
    bin-version-check  2.1.0 - 5.0.0
    Depends on vulnerable versions of semver-truncate
    node_modules/bin-version-check

3 moderate severity vulnerabilities

To address all issues, run:
  npm audit fix --force
```

After updating `bin-version-check`to `~5.1.0`:

```shell
% npm audit --production
npm WARN config production Use `--omit=dev` instead.
found 0 vulnerabilities

```

Changes in `bin-version-check` from  `5.0.0` to `5.1.0`:
https://github.com/sindresorhus/bin-version-check/compare/v5.0.0...v5.1.0