### PR TITLE
fix: post-install should fail on error

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -42,7 +42,16 @@ const getBinary = async url => {
 }
 
 if (!YOUTUBE_DL_SKIP_DOWNLOAD) {
-  Promise.all([getBinary(YOUTUBE_DL_HOST), mkdirp(YOUTUBE_DL_DIR)])
-    .then(([buffer]) => writeFile(YOUTUBE_DL_PATH, buffer, { mode: 0o755 }))
-    .catch(err => console.error(err.message || err))
+  ;(async () => {
+    try {
+      const [buffer] = await Promise.all([
+        getBinary(YOUTUBE_DL_HOST),
+        mkdirp(YOUTUBE_DL_DIR)
+      ])
+      await writeFile(YOUTUBE_DL_PATH, buffer, { mode: 0o755 })
+    } catch (err) {
+      console.error(err.message || err)
+      process.exit(1)
+    }
+  })()
 }


### PR DESCRIPTION
Fixes #190.

Weird observation, failure cases always take a minimum of 30s. I guess `simple-get` is not keeping things as simple as it should.

I'll investigate that if I get the time.