### PR TITLE
feat!: rewrite the postinstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ These environment variables can also be set through "npm config", for example `n
 
 They setup the download configuration for getting the `yt-dlp` binary file.
 
+### DEBUG
+
+Set `DEBUG="youtube-dl-exec*"` to enable debug mode. This will enable log additional information during the post-install script.
+
 ### YOUTUBE_DL_DIR
 
 It determines the folder where to put the binary file.

--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
     "dargs": "~7.0.0",
     "debug-logfmt": "~1.2.2",
     "is-unix": "~2.0.10",
-    "simple-get": "~4.0.1",
     "tinyspawn": "~1.2.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
   "dependencies": {
     "bin-version-check": "~6.0.0",
     "dargs": "~7.0.0",
+    "debug-logfmt": "~1.2.2",
     "is-unix": "~2.0.10",
     "simple-get": "~4.0.1",
     "tinyspawn": "~1.2.6"

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "tsd": "latest"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   },
   "files": [
     "scripts",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -42,7 +42,16 @@ const getBinary = async url => {
 }
 
 if (!YOUTUBE_DL_SKIP_DOWNLOAD) {
-  Promise.all([getBinary(YOUTUBE_DL_HOST), mkdirp(YOUTUBE_DL_DIR)])
-    .then(([buffer]) => writeFile(YOUTUBE_DL_PATH, buffer, { mode: 0o755 }))
-    .catch(err => console.error(err.message || err))
+  ;(async () => {
+    try {
+      const [buffer] = await Promise.all([
+        getBinary(YOUTUBE_DL_HOST),
+        mkdirp(YOUTUBE_DL_DIR)
+      ])
+      await writeFile(YOUTUBE_DL_PATH, buffer, { mode: 0o755 })
+    } catch (err) {
+      console.error(err.message || err)
+      process.exit(1)
+    }
+  })()
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -13,8 +13,7 @@ const {
   YOUTUBE_DL_SKIP_DOWNLOAD
 } = require('../src/constants')
 
-const getLatest = data => {
-  const { assets } = data
+const getLatest = ({ assets }) => {
   const { browser_download_url: url } = assets.find(
     ({ name }) => name === YOUTUBE_DL_FILE
   )

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -4,14 +4,6 @@ const debug = require('debug-logfmt')('youtube-dl-exec:install')
 const { mkdir, chmod } = require('node:fs/promises')
 const { pipeline } = require('node:stream/promises')
 const { createWriteStream } = require('node:fs')
-const { Readable } = require('node:stream')
-
-const httpGet = async url =>
-  fetch(url, {
-    headers: {
-      'user-agent': 'microlinkhq/youtube-dl-exec'
-    }
-  })
 
 const {
   YOUTUBE_DL_PATH,
@@ -21,20 +13,20 @@ const {
   YOUTUBE_DL_SKIP_DOWNLOAD
 } = require('../src/constants')
 
-const getLatest = async data => {
+const getLatest = data => {
   const { assets } = data
   const { browser_download_url: url } = assets.find(
     ({ name }) => name === YOUTUBE_DL_FILE
   )
-  return httpGet(url)
+  return fetch(url)
 }
 
 const getBinary = async url => {
-  let response = await httpGet(url)
+  let response = await fetch(url)
   if (response.headers.get('content-type') !== 'application/octet-stream') {
     response = await getLatest(await response.json())
   }
-  return Readable.fromWeb(response.body)
+  return response.body
 }
 
 const installBinary = async () => {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -34,8 +34,8 @@ const installBinary = async () => {
     getBinary(YOUTUBE_DL_HOST),
     mkdir(YOUTUBE_DL_DIR, { recursive: true })
   ])
-  await pipeline(binary, createWriteStream(YOUTUBE_DL_PATH))
   debug('writing', { path: YOUTUBE_DL_PATH })
+  await pipeline(binary, createWriteStream(YOUTUBE_DL_PATH))
   await chmod(YOUTUBE_DL_PATH, 0o755)
   debug({ status: 'success' })
 }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -6,8 +6,6 @@ const { pipeline } = require('node:stream/promises')
 const { createWriteStream } = require('node:fs')
 const { Readable } = require('node:stream')
 
-const mkdirp = filepath => mkdir(filepath, { recursive: true })
-
 const httpGet = async url =>
   fetch(url, {
     headers: {
@@ -43,7 +41,7 @@ const installBinary = async () => {
   debug('downloading', { url: YOUTUBE_DL_HOST })
   const [binary] = await Promise.all([
     getBinary(YOUTUBE_DL_HOST),
-    mkdirp(YOUTUBE_DL_DIR)
+    mkdir(YOUTUBE_DL_DIR, { recursive: true })
   ])
   await pipeline(binary, createWriteStream(YOUTUBE_DL_PATH))
   debug('writing', { path: YOUTUBE_DL_PATH })

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,29 +1,19 @@
 'use strict'
 
-const { tmpdir } = require('node:os')
-const { Readable } = require('node:stream')
+const debug = require('debug-logfmt')('youtube-dl-exec:install')
+const { mkdir, chmod } = require('node:fs/promises')
 const { pipeline } = require('node:stream/promises')
-const { randomBytes } = require('node:crypto')
 const { createWriteStream } = require('node:fs')
-const { mkdir, chmod, rename } = require('node:fs/promises')
+const { Readable } = require('node:stream')
 
 const mkdirp = filepath => mkdir(filepath, { recursive: true })
 
-const log = (...args) => console.log('[youtube-dl-exec]', ...args)
-
-const get = async url => {
-  const response = await fetch(url, {
+const httpGet = async url =>
+  fetch(url, {
     headers: {
       'user-agent': 'microlinkhq/youtube-dl-exec'
     }
   })
-
-  return {
-    headers: response.headers,
-    stream: () => Readable.fromWeb(response.body),
-    json: () => response.json()
-  }
-}
 
 const {
   YOUTUBE_DL_PATH,
@@ -38,54 +28,27 @@ const getLatest = async data => {
   const { browser_download_url: url } = assets.find(
     ({ name }) => name === YOUTUBE_DL_FILE
   )
-  return get(url)
+  return httpGet(url)
 }
 
 const getBinary = async url => {
-  let response = await get(url)
+  let response = await httpGet(url)
   if (response.headers.get('content-type') !== 'application/octet-stream') {
     response = await getLatest(await response.json())
   }
-  return response.stream()
+  return Readable.fromWeb(response.body)
 }
 
 const installBinary = async () => {
-  log('Downloading `youtube-dl` binary')
-
-  const binary = await getBinary(YOUTUBE_DL_HOST)
-
-  const tmpfile = `${tmpdir()}/yt-dl-exec-${randomBytes(4).toString('hex')}`
-
-  log(`Download Location: \`${tmpfile}\``)
-
-  await pipeline(binary, createWriteStream(tmpfile))
-
-  log(`Ensuring directory exists: \`${YOUTUBE_DL_DIR}\``)
-
-  await mkdirp(YOUTUBE_DL_DIR)
-
-  log(`Moving binary to \`${YOUTUBE_DL_PATH}\``)
-
-  await rename(tmpfile, YOUTUBE_DL_PATH)
-
-  log(`Setting permissions for \`${YOUTUBE_DL_PATH}\``)
-
+  debug('downloading', { url: YOUTUBE_DL_HOST })
+  const [binary] = await Promise.all([
+    getBinary(YOUTUBE_DL_HOST),
+    mkdirp(YOUTUBE_DL_DIR)
+  ])
+  await pipeline(binary, createWriteStream(YOUTUBE_DL_PATH))
+  debug('writing', { path: YOUTUBE_DL_PATH })
   await chmod(YOUTUBE_DL_PATH, 0o755)
-
-  log('Installation complete')
+  debug({ status: 'success' })
 }
 
-const main = async () => {
-  if (YOUTUBE_DL_SKIP_DOWNLOAD) {
-    return log('Skipping `youtube-dl` binary download')
-  }
-
-  try {
-    await installBinary()
-  } catch (err) {
-    console.error(err)
-    process.exit(1)
-  }
-}
-
-main()
+YOUTUBE_DL_SKIP_DOWNLOAD ? debug({ status: 'skipped' }) : installBinary()

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -9,9 +9,7 @@ const { mkdir, chmod, rename } = require('node:fs/promises')
 
 const mkdirp = filepath => mkdir(filepath, { recursive: true })
 
-const log = (...args) =>
-  'npm_lifecycle_event' in process.env ||
-  console.log('[youtube-dl-exec]', ...args)
+const log = (...args) => console.log('[youtube-dl-exec]', ...args)
 
 const get = async url => {
   const response = await fetch(url, {

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,22 +1,31 @@
 'use strict'
 
-const { writeFile, mkdir } = require('fs/promises')
-const { concat } = require('simple-get')
+const { tmpdir } = require('node:os')
+const { Readable } = require('node:stream')
+const { pipeline } = require('node:stream/promises')
+const { randomBytes } = require('node:crypto')
+const { createWriteStream } = require('node:fs')
+const { mkdir, chmod, rename } = require('node:fs/promises')
 
-const mkdirp = filepath => mkdir(filepath, { recursive: true }).catch(() => {})
+const mkdirp = filepath => mkdir(filepath, { recursive: true })
 
-const get = url =>
-  new Promise((resolve, reject) =>
-    concat(
-      {
-        url,
-        headers: {
-          'user-agent': 'microlinkhq/youtube-dl-exec'
-        }
-      },
-      (err, response, data) => (err ? reject(err) : resolve({ response, data }))
-    )
-  )
+const log = (...args) =>
+  'npm_lifecycle_event' in process.env ||
+  console.log('[youtube-dl-exec]', ...args)
+
+const get = async url => {
+  const response = await fetch(url, {
+    headers: {
+      'user-agent': 'microlinkhq/youtube-dl-exec'
+    }
+  })
+
+  return {
+    headers: response.headers,
+    stream: () => Readable.fromWeb(response.body),
+    json: () => response.json()
+  }
+}
 
 const {
   YOUTUBE_DL_PATH,
@@ -26,32 +35,59 @@ const {
   YOUTUBE_DL_SKIP_DOWNLOAD
 } = require('../src/constants')
 
-const getLatest = data => {
-  const { assets } = JSON.parse(data)
+const getLatest = async data => {
+  const { assets } = data
   const { browser_download_url: url } = assets.find(
     ({ name }) => name === YOUTUBE_DL_FILE
   )
-  return get(url).then(({ data }) => data)
+  return get(url)
 }
 
 const getBinary = async url => {
-  const { response, data } = await get(url)
-  return response.headers['content-type'] === 'application/octet-stream'
-    ? data
-    : getLatest(data)
+  let response = await get(url)
+  if (response.headers.get('content-type') !== 'application/octet-stream') {
+    response = await getLatest(await response.json())
+  }
+  return response.stream()
 }
 
-if (!YOUTUBE_DL_SKIP_DOWNLOAD) {
-  ;(async () => {
-    try {
-      const [buffer] = await Promise.all([
-        getBinary(YOUTUBE_DL_HOST),
-        mkdirp(YOUTUBE_DL_DIR)
-      ])
-      await writeFile(YOUTUBE_DL_PATH, buffer, { mode: 0o755 })
-    } catch (err) {
-      console.error(err.message || err)
-      process.exit(1)
-    }
-  })()
+const installBinary = async () => {
+  log('Downloading `youtube-dl` binary')
+
+  const binary = await getBinary(YOUTUBE_DL_HOST)
+
+  const tmpfile = `${tmpdir()}/yt-dl-exec-${randomBytes(4).toString('hex')}`
+
+  log(`Download Location: \`${tmpfile}\``)
+
+  await pipeline(binary, createWriteStream(tmpfile))
+
+  log(`Ensuring directory exists: \`${YOUTUBE_DL_DIR}\``)
+
+  await mkdirp(YOUTUBE_DL_DIR)
+
+  log(`Moving binary to \`${YOUTUBE_DL_PATH}\``)
+
+  await rename(tmpfile, YOUTUBE_DL_PATH)
+
+  log(`Setting permissions for \`${YOUTUBE_DL_PATH}\``)
+
+  await chmod(YOUTUBE_DL_PATH, 0o755)
+
+  log('Installation complete')
 }
+
+const main = async () => {
+  if (YOUTUBE_DL_SKIP_DOWNLOAD) {
+    return log('Skipping youtube-dl binary download')
+  }
+
+  try {
+    await installBinary()
+  } catch (err) {
+    console.error(err)
+    process.exit(1)
+  }
+}
+
+main()

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -77,7 +77,7 @@ const installBinary = async () => {
 
 const main = async () => {
   if (YOUTUBE_DL_SKIP_DOWNLOAD) {
-    return log('Skipping youtube-dl binary download')
+    return log('Skipping `youtube-dl` binary download')
   }
 
   try {


### PR DESCRIPTION
Branched off #191

Swaps out `simple-get` for `fetch`, and uses streams instead of buffering the whole binary in memory.

```console
$ node ./scripts/postinstall.js
[youtube-dl-exec] Downloading `youtube-dl` binary
[youtube-dl-exec] Download Location: `/var/folders/(...)/T/yt-dl-exec-10fffb83`
[youtube-dl-exec] Ensuring directory exists: `/git/microlinkhq/youtube-dl-exec/bin`
[youtube-dl-exec] Moving binary to `/git/microlinkhq/youtube-dl-exec/bin/yt-dlp`
[youtube-dl-exec] Setting permissions for `/git/microlinkhq/youtube-dl-exec/bin/yt-dlp`
[youtube-dl-exec] Installation complete
```

Tested with `npm`, `yarn` and `pnpm`, and they all hide `std{out,err}` logs from post-install scripts on install unless the run fails. You can confirm this as well.