### PR TITLE
Fix: Update deprecated `bin-version-check` package due to name change

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "youtube-downloader"
   ],
   "dependencies": {
-    "bin-version-check": "~6.0.0",
+    "binary-version-check": "~6.1.0",
     "dargs": "~7.0.0",
     "debug-logfmt": "~1.2.2",
     "is-unix": "~2.0.10",

--- a/scripts/preinstall.mjs
+++ b/scripts/preinstall.mjs
@@ -1,4 +1,4 @@
-import binaryVersionCheck from 'bin-version-check'
+import binaryVersionCheck from 'binary-version-check'
 
 const throwError = error => {
   throw new Error(


### PR DESCRIPTION
This pull request updates the bin-version-check package to resolve a deprecation warning. The package was deprecated due to a name change.