### PR TITLE
fix(types): add missing fields

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -433,7 +433,7 @@ export type Flags = {
   xattrSetFilesize?: boolean
   yesPlaylist?: boolean
   youtubeSkipDashManifest?: boolean
-  noCheckFormats: boolean
+  noCheckFormats?: boolean
 }
 
 export type Exec = (url: string, flags?: Flags, options?: SpawnOptions) => TinyspawnPromise


### PR DESCRIPTION
This PR adds missing fields to the type definitions.

`artists`, `track`, `release_date`, `release_year` fields may be included when the video is Auto-generated by YouTube