### PR TITLE
fix: pass authorization header to fetch in postinstall

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -25,9 +25,9 @@ const getBinary = async url => {
   const headers = GITHUB_TOKEN
     ? { Authorization: `Bearer ${GITHUB_TOKEN}` }
     : {}
-  let response = await fetch(url, headers)
+  let response = await fetch(url, { headers })
 
-  if (!response.headers.get('content-type') !== 'application/octet-stream') {
+  if (response.headers.get('content-type') !== 'application/octet-stream') {
     const payload = await response.json()
     if (!response.ok) throw new Error(JSON.stringify(payload, null, 2))
     response = await getLatest(payload)

--- a/test/postinstall.js
+++ b/test/postinstall.js
@@ -1,0 +1,95 @@
+'use strict'
+
+const { mkdtemp, readdir, readFile } = require('node:fs/promises')
+const { spawn } = require('node:child_process')
+const { createServer } = require('node:http')
+const { once } = require('node:events')
+const { tmpdir } = require('node:os')
+const path = require('node:path')
+
+const test = require('ava')
+
+const SCRIPT_PATH = path.join(__dirname, '..', 'scripts', 'postinstall.js')
+
+const runPostinstall = env =>
+  new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [SCRIPT_PATH], { env })
+    let stderr = ''
+    child.stderr.on('data', chunk => (stderr += chunk))
+    child.on('error', reject)
+    child.on('close', code =>
+      code === 0 ? resolve() : reject(new Error(stderr))
+    )
+  })
+
+const createFixtureServer = async handler => {
+  const server = createServer(handler)
+  server.listen(0, '127.0.0.1')
+  await once(server, 'listening')
+  return { server, origin: `http://127.0.0.1:${server.address().port}` }
+}
+
+const createEnv = extra => {
+  const { GITHUB_TOKEN, GH_TOKEN, ...env } = process.env
+  return { ...env, ...extra }
+}
+
+const readBinary = async dir => {
+  const [file] = await readdir(dir)
+  return readFile(path.join(dir, file), 'utf8')
+}
+
+test('forwards the GitHub token as authorization header', async t => {
+  let authorization
+  const { server, origin } = await createFixtureServer((req, res) => {
+    if (req.url === '/release') {
+      authorization = req.headers.authorization
+      res.setHeader('content-type', 'application/json')
+      return res.end(
+        JSON.stringify({
+          assets: ['yt-dlp', 'yt-dlp.exe'].map(name => ({
+            name,
+            browser_download_url: `http://${req.headers.host}/download`
+          }))
+        })
+      )
+    }
+    res.setHeader('content-type', 'application/octet-stream')
+    res.end('binary content')
+  })
+
+  const dir = await mkdtemp(path.join(tmpdir(), 'youtube-dl-exec-'))
+
+  await runPostinstall(
+    createEnv({
+      GITHUB_TOKEN: 'test-token',
+      YOUTUBE_DL_HOST: `${origin}/release`,
+      YOUTUBE_DL_DIR: dir
+    })
+  )
+
+  server.close()
+
+  t.is(authorization, 'Bearer test-token')
+  t.is(await readBinary(dir), 'binary content')
+})
+
+test('downloads directly when the response is a binary stream', async t => {
+  const { server, origin } = await createFixtureServer((req, res) => {
+    res.setHeader('content-type', 'application/octet-stream')
+    res.end('binary content')
+  })
+
+  const dir = await mkdtemp(path.join(tmpdir(), 'youtube-dl-exec-'))
+
+  await runPostinstall(
+    createEnv({
+      YOUTUBE_DL_HOST: `${origin}/binary`,
+      YOUTUBE_DL_DIR: dir
+    })
+  )
+
+  server.close()
+
+  t.is(await readBinary(dir), 'binary content')
+})


### PR DESCRIPTION
## Problem

In `scripts/postinstall.js`, `getBinary()` builds an auth headers object from `GITHUB_TOKEN`/`GH_TOKEN` but passes it as the fetch **options** object instead of nesting it under `headers`:

```js
let response = await fetch(url, headers)   // headers silently ignored
```

`fetch` ignores unknown top-level options, so the `Authorization` header is silently dropped and the call to `https://api.github.com/repos/yt-dlp/yt-dlp/releases/latest` is **always unauthenticated** — even when a token is configured.

### Failure mode

Unauthenticated GitHub API requests are limited to **60 requests/hour per IP**. On shared CI egress IPs (Docker builds, hosted runners) that limit is exhausted quickly by other tenants, so `npm install` fails during postinstall with a rate-limit error, and setting `GITHUB_TOKEN` doesn't help because the header never leaves the process. We hit this in our Trigger.dev Docker builds and had to pin the binary as a workaround.

## Fix

```js
let response = await fetch(url, { headers })
```

This PR also fixes a second latent bug on the next line:

```js
if (!response.headers.get('content-type') !== 'application/octet-stream') {
```

The `!` negates the header value to a boolean before comparing it to a string, so the condition is always true. That happens to work for the GitHub API flow (JSON → follow `browser_download_url`), but it breaks pointing `YOUTUBE_DL_HOST` directly at a binary URL: the script tries to `JSON.parse` the binary and crashes. Fixed by dropping the stray `!`.

## Tests

Added `test/postinstall.js` (ava, no network — runs the script as a child process against a local HTTP fixture server):

1. asserts the `Authorization: Bearer <token>` header actually reaches the release API endpoint and the resolved asset is written to `YOUTUBE_DL_DIR`
2. asserts a direct `application/octet-stream` response is streamed to disk without the JSON round-trip

Both tests fail on `master` and pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)