### PR TITLE
fix: try-catch when fetching data from gh with a bad token

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -21,22 +21,21 @@ const getLatest = ({ assets }) => {
   return fetch(url)
 }
 
-const getBinary = async url => {
-  const headers = GITHUB_TOKEN
-    ? { Authorization: `Bearer ${GITHUB_TOKEN}` }
-    : {}
+const UNAUTHORIZED_STATUS = new Set([401, 403])
 
-  try {
-    const response = await fetch(url, { headers })
-    return await handleResponse(response)
-  } catch (error) {
-    if (!GITHUB_TOKEN) throw error
-    const response = await fetch(url)
-    return await handleResponse(response)
-  }
+const fetchWithToken = async url => {
+  const response = await fetch(url, {
+    headers: { Authorization: `Bearer ${GITHUB_TOKEN}` }
+  })
+  if (!UNAUTHORIZED_STATUS.has(response.status)) return response
+  debug('token rejected, retrying anonymously', { status: response.status })
+  await response.body?.cancel()
+  return fetch(url)
 }
 
-const handleResponse = async (response) => {
+const getBinary = async url => {
+  let response = GITHUB_TOKEN ? await fetchWithToken(url) : await fetch(url)
+
   if (response.headers.get('content-type') !== 'application/octet-stream') {
     const payload = await response.json()
     if (!response.ok) throw new Error(JSON.stringify(payload, null, 2))

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -28,7 +28,6 @@ const request = async url => {
   })
   if (response.status !== 401 && response.status !== 403) return response
   debug('token rejected, retrying anonymously', { status: response.status })
-  await response.body?.cancel()
   return fetch(url)
 }
 

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -21,20 +21,19 @@ const getLatest = ({ assets }) => {
   return fetch(url)
 }
 
-const UNAUTHORIZED_STATUS = new Set([401, 403])
-
-const fetchWithToken = async url => {
+const request = async url => {
+  if (!GITHUB_TOKEN) return fetch(url)
   const response = await fetch(url, {
     headers: { Authorization: `Bearer ${GITHUB_TOKEN}` }
   })
-  if (!UNAUTHORIZED_STATUS.has(response.status)) return response
+  if (response.status !== 401 && response.status !== 403) return response
   debug('token rejected, retrying anonymously', { status: response.status })
   await response.body?.cancel()
   return fetch(url)
 }
 
 const getBinary = async url => {
-  let response = GITHUB_TOKEN ? await fetchWithToken(url) : await fetch(url)
+  let response = await request(url)
 
   if (response.headers.get('content-type') !== 'application/octet-stream') {
     const payload = await response.json()

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -25,8 +25,17 @@ const getBinary = async url => {
   const headers = GITHUB_TOKEN
     ? { Authorization: `Bearer ${GITHUB_TOKEN}` }
     : {}
-  let response = await fetch(url, { headers })
 
+  try {
+    const response = await fetch(url, { headers })
+    return await handleResponse(response)
+  } catch {
+    const response = await fetch(url)
+    return await handleResponse(response)
+  }
+}
+
+const handleResponse = async (response) => {
   if (response.headers.get('content-type') !== 'application/octet-stream') {
     const payload = await response.json()
     if (!response.ok) throw new Error(JSON.stringify(payload, null, 2))

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -29,7 +29,8 @@ const getBinary = async url => {
   try {
     const response = await fetch(url, { headers })
     return await handleResponse(response)
-  } catch {
+  } catch (error) {
+    if (!GITHUB_TOKEN) throw error
     const response = await fetch(url)
     return await handleResponse(response)
   }

--- a/test/postinstall.js
+++ b/test/postinstall.js
@@ -74,6 +74,72 @@ test('forwards the GitHub token as authorization header', async t => {
   t.is(await readBinary(dir), 'binary content')
 })
 
+test('retries anonymously when the GitHub token is rejected', async t => {
+  const authorizations = []
+  const { server, origin } = await createFixtureServer((req, res) => {
+    if (req.url === '/release') {
+      authorizations.push(req.headers.authorization)
+      res.setHeader('content-type', 'application/json')
+      if (req.headers.authorization) {
+        res.statusCode = 401
+        return res.end(JSON.stringify({ message: 'Bad credentials' }))
+      }
+      return res.end(
+        JSON.stringify({
+          assets: ['yt-dlp', 'yt-dlp.exe'].map(name => ({
+            name,
+            browser_download_url: `http://${req.headers.host}/download`
+          }))
+        })
+      )
+    }
+    res.setHeader('content-type', 'application/octet-stream')
+    res.end('binary content')
+  })
+
+  const dir = await mkdtemp(path.join(tmpdir(), 'youtube-dl-exec-'))
+
+  await runPostinstall(
+    createEnv({
+      GITHUB_TOKEN: 'bad-token',
+      YOUTUBE_DL_HOST: `${origin}/release`,
+      YOUTUBE_DL_DIR: dir
+    })
+  )
+
+  server.close()
+
+  t.deepEqual(authorizations, ['Bearer bad-token', undefined])
+  t.is(await readBinary(dir), 'binary content')
+})
+
+test('surfaces non authorization errors without retrying', async t => {
+  let requests = 0
+  const { server, origin } = await createFixtureServer((req, res) => {
+    requests++
+    res.statusCode = 500
+    res.setHeader('content-type', 'application/json')
+    res.end(JSON.stringify({ message: 'upstream exploded' }))
+  })
+
+  const dir = await mkdtemp(path.join(tmpdir(), 'youtube-dl-exec-'))
+
+  const error = await t.throwsAsync(
+    runPostinstall(
+      createEnv({
+        GITHUB_TOKEN: 'good-token',
+        YOUTUBE_DL_HOST: `${origin}/release`,
+        YOUTUBE_DL_DIR: dir
+      })
+    )
+  )
+
+  server.close()
+
+  t.true(error.message.includes('upstream exploded'))
+  t.is(requests, 1)
+})
+
 test('downloads directly when the response is a binary stream', async t => {
   const { server, origin } = await createFixtureServer((req, res) => {
     res.setHeader('content-type', 'application/octet-stream')


### PR DESCRIPTION
- bug introduced in #278
- fixes #281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary downloads by retrying anonymously when configured authorization credentials are rejected.
  * Added safer handling for failed download responses, including authorization errors.
  * Downloads now avoid unnecessary retries for unrelated server errors and surface those failures directly.

* **Tests**
  * Added coverage for authorization failures, successful fallback downloads, and non-retryable errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->